### PR TITLE
[Fix] 입양 신청 동시성 문제 개선

### DIFF
--- a/backend/settings.gradle
+++ b/backend/settings.gradle
@@ -1,1 +1,0 @@
-rootProject.name = 'TenPaws'

--- a/backend/src/main/java/com/example/tenpaws/domain/apply/controller/ApplyController.java
+++ b/backend/src/main/java/com/example/tenpaws/domain/apply/controller/ApplyController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -23,11 +24,14 @@ public class ApplyController {
 
     // 회원의 입양 신청
     @Operation(summary = "입양 신청", description = "입양 신청 API")
-    @PreAuthorize("hasRole('ROLE_USER') and @userServiceImpl.isUserOwn(#userId)")
+    @PreAuthorize("hasRole('ROLE_USER')")
     @PostMapping
-    public ResponseEntity<ApplyDto> applyForPet(@RequestParam Long petId, @RequestParam Long userId) {
-            ApplyDto apply = applyService.applyForPet(petId, userId);
-            return ResponseEntity.ok(apply);
+    public ResponseEntity<ApplyDto> applyForPet(
+            @RequestParam Long petId,
+            Authentication authentication) {
+        String email = authentication.getName();
+        ApplyDto apply = applyService.applyForPet(petId, email);
+        return ResponseEntity.ok(apply);
     }
 
     // 입양 신청 취소

--- a/backend/src/main/java/com/example/tenpaws/domain/pet/repository/PetRepository.java
+++ b/backend/src/main/java/com/example/tenpaws/domain/pet/repository/PetRepository.java
@@ -2,7 +2,13 @@ package com.example.tenpaws.domain.pet.repository;
 
 import com.example.tenpaws.domain.pet.entity.Pet;
 import com.example.tenpaws.domain.shelter.entity.Shelter;
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.QueryHint;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -13,4 +19,8 @@ public interface PetRepository extends JpaRepository<Pet, Long> {
     List<Pet> findByShelter(Shelter shelter);
     Optional<Pet> findByIdAndStatus(Long id, Pet.PetStatus status);
 
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints({@QueryHint(name = "jakarta.persistence.lock.timeout", value = "3000")})
+    @Query("select p from Pet p where p.id = :id")
+    Optional<Pet> findByIdWithPessimisticLock(@Param("id") Long id);
 }

--- a/backend/src/main/java/com/example/tenpaws/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/example/tenpaws/global/exception/ErrorCode.java
@@ -75,7 +75,9 @@ public enum ErrorCode {
 
     // Apply
     APPLICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "Application not found"),
-    USER_NOT_AUTHORIZED(HttpStatus.FORBIDDEN, "You are not owner"),;
+    USER_NOT_AUTHORIZED(HttpStatus.FORBIDDEN, "You are not owner"),
+    LOCK_ACQUISITION_FAILED(HttpStatus.CONFLICT, "Could not acquire lock. Please try again later"),
+    OPERATION_TIMEOUT(HttpStatus.REQUEST_TIMEOUT, "Operation timed out. Please try again later");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/backend/src/main/java/com/example/tenpaws/global/util/TestDataScriptGenerator.java
+++ b/backend/src/main/java/com/example/tenpaws/global/util/TestDataScriptGenerator.java
@@ -1,0 +1,60 @@
+//package com.example.tenpaws.global.util;
+//
+//import java.io.*;
+//import java.nio.charset.StandardCharsets;
+//
+//public class TestDataScriptGenerator {
+//    private static final String PASSWORD = "$2a$10$BuCFwfmsYeHDjMGbolqOMe3XRPiXMbzwUokpaglBM8J08A5PxzLsu";
+//    private static final int NUM_USERS = 100;
+//
+//    public static void generateTestDataScript() {
+//        String projectDir = System.getProperty("user.dir");
+//        String resourcePath = projectDir + "/backend/src/main/resources/data.sql";
+//
+//        File resourceDir = new File(projectDir + "/backend/src/main/resources");
+//        if (!resourceDir.exists()) {
+//            resourceDir.mkdirs();
+//        }
+//
+//        try (BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(
+//                new FileOutputStream(resourcePath), StandardCharsets.UTF_8))) {
+//
+//            // 기존 데이터 삭제
+//            writer.write("SET FOREIGN_KEY_CHECKS = 0;\n");
+//            writer.write("DELETE FROM apply;\n");
+//            writer.write("DELETE FROM pet_images;\n");
+//            writer.write("DELETE FROM pets;\n");
+//            writer.write("DELETE FROM Users;\n");
+//            writer.write("DELETE FROM Shelters;\n");
+//            writer.write("DELETE FROM Notifications;\n");
+//            writer.write("ALTER TABLE Shelters AUTO_INCREMENT = 1;\n");
+//            writer.write("SET FOREIGN_KEY_CHECKS = 1;\n\n");
+//
+//            // 사용자 데이터 생성
+//            writer.write("INSERT INTO Users (email, username, password, birth_date, phone_number, address, user_role) VALUES\n");
+//            for (int i = 1; i <= NUM_USERS; i++) {
+//                String username = String.format("user%d", i);
+//                String email = String.format("user%d@test.com", i);
+//                String line = String.format("('%s', '%s', '%s', '1990-01-01', '010-1234-5678', 'Test Address %d', 'ROLE_USER')%s\n",
+//                        email, username, PASSWORD, i, (i == NUM_USERS ? ";" : ","));
+//                writer.write(line);
+//            }
+//
+//            // 보호소 데이터 생성
+//            writer.write("\nINSERT INTO Shelters (shelter_name, email, password, phone_number, address, user_role) VALUES\n");
+//            writer.write("('Test Shelter', 'shelter@test.com', '" + PASSWORD + "', '02-1234-5678', 'Shelter Address', 'ROLE_SHELTER');\n");
+//
+//            // 반려동물 데이터 생성 (SELECT 문을 사용하여 shelter_id 참조)
+//            writer.write("\nINSERT INTO pets (pet_name, species, size, age, gender, neutering, reason, pre_adoption, personality, exercise_level, shelter_id, status)\n");
+//            writer.write("SELECT 'TestPet', '강아지', 'MEDIUM', '2', 'MALE', 'YES', 'Test Purpose', 'None', 'Friendly', 3, shelter_id, 'AVAILABLE'\n");
+//            writer.write("FROM Shelters WHERE email = 'shelter@test.com';\n");
+//
+//        } catch (IOException e) {
+//            e.printStackTrace();
+//        }
+//    }
+//
+//    public static void main(String[] args) {
+//        generateTestDataScript();
+//    }
+//}

--- a/backend/src/test/java/com/example/tenpaws/PasswordEncoderTest.java
+++ b/backend/src/test/java/com/example/tenpaws/PasswordEncoderTest.java
@@ -1,0 +1,15 @@
+//package com.example.tenpaws;
+//
+//import org.junit.jupiter.api.Test;
+//import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+//
+//public class PasswordEncoderTest {
+//
+//    @Test
+//    public void encodePassword() {
+//        BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
+//        String rawPassword = "examplePassword";  // 암호화하고자 하는 원본 비밀번호
+//        String encodedPassword = encoder.encode(rawPassword);
+//        System.out.println("Encoded password: " + encodedPassword);
+//    }
+//}


### PR DESCRIPTION
## 🛰️ Issue Number
- #21 
## 🪐 작업 내용
- 여러 사용자가 하나의 유기동물에 대해 동시에 입양 신청시 데이터 무결성이 위반되는 문제 해결

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
- [x] Project를 지정했나요?

## ✅ PR 포인트 & 궁금한 점
- 입양 신청 시, 토큰 정보로 유저 정보를 얻도록 개선하여 클라이언트가 파라미터에 userId값을 직접 입력해야 하는 문제를 해결
- 입양 신청 기능에 비관적 락(Pessimistic Lock)을 적용하여 현재 서비스에서 발생하는 경쟁 상태 문제를 해결하였습니다.
- close #21 
