### PR TITLE
[Feat] 동물 자기소개(AI 응답) 추가+[Mod] AI 입력 로직 개선

### DIFF
--- a/backend/src/main/java/com/example/tenpaws/domain/pet/controller/PetController.java
+++ b/backend/src/main/java/com/example/tenpaws/domain/pet/controller/PetController.java
@@ -12,6 +12,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
@@ -59,7 +60,7 @@ public class PetController {
     public ResponseEntity<PetResponseDTO> createPet(
             @PathVariable Long shelterId,
             @RequestPart("petData") PetRequestDTO petRequestDTO,
-            @RequestPart(value = "images", required = false) List<MultipartFile> images) {
+            @RequestPart(value = "images", required = false) List<MultipartFile> images) throws IOException {
         petRequestDTO.setImages(images);
         PetResponseDTO createdPet = petService.createPet(shelterId, petRequestDTO);
         return ResponseEntity.ok(createdPet);

--- a/backend/src/main/java/com/example/tenpaws/domain/pet/dto/PetRequestDTO.java
+++ b/backend/src/main/java/com/example/tenpaws/domain/pet/dto/PetRequestDTO.java
@@ -36,7 +36,7 @@ public class PetRequestDTO {
     private String preAdoption;
     private String vaccinated;
     private String extra;
-    private String introduction;
+    private String description;
     private String personality;
     private String exerciseLevel;
     private List<MultipartFile> images; // Store multiple image files
@@ -54,7 +54,7 @@ public class PetRequestDTO {
                 .preAdoption(this.preAdoption)
                 .vaccinated(this.vaccinated)
                 .extra(this.extra)
-                .introduction(this.introduction)
+                .description(this.description)
                 .personality(this.personality)
                 .exerciseLevel(this.exerciseLevel)
                 .shelter(shelter)

--- a/backend/src/main/java/com/example/tenpaws/domain/pet/dto/PetResponseDTO.java
+++ b/backend/src/main/java/com/example/tenpaws/domain/pet/dto/PetResponseDTO.java
@@ -22,7 +22,7 @@ public class PetResponseDTO {
     private final String preAdoption;
     private final String vaccinated;
     private final String extra;
-    private final String introduction;
+    private final String description;
     private final String personality;
     private final String exerciseLevel;
     private final Long shelterId;
@@ -45,7 +45,7 @@ public class PetResponseDTO {
                 .preAdoption(pet.getPreAdoption())
                 .vaccinated(pet.getVaccinated())
                 .extra(pet.getExtra())
-                .introduction(pet.getIntroduction())
+                .description(pet.getDescription())
                 .personality(pet.getPersonality())
                 .exerciseLevel(pet.getExerciseLevel())
                 .shelterId(pet.getShelter().getId())

--- a/backend/src/main/java/com/example/tenpaws/domain/pet/entity/Pet.java
+++ b/backend/src/main/java/com/example/tenpaws/domain/pet/entity/Pet.java
@@ -55,8 +55,8 @@ public class Pet {
     @Column(name = "extra")
     private String extra;
 
-    @Column(name = "introduction")
-    private String introduction;
+    @Column(name = "description", length = 500)
+    private String description;
 
     @Column(name = "personality", nullable = false)
     private String personality;
@@ -93,7 +93,7 @@ public class Pet {
     @Builder
     public Pet(Long id, String petName, Species species,  String size, String age, String gender, String neutering, String reason,
                String preAdoption, String vaccinated, String extra, String personality, String exerciseLevel, Shelter shelter,
-               List<String> imageUrls, PetStatus status, String introduction) {
+               List<String> imageUrls, PetStatus status, String description) {
         this.id = id;
         this.petName = petName;
         this.species = species;
@@ -105,7 +105,7 @@ public class Pet {
         this.preAdoption = preAdoption;
         this.vaccinated = vaccinated;
         this.extra = extra;
-        this.introduction = introduction;
+        this.description = description;
         this.personality = personality;
         this.exerciseLevel = exerciseLevel;
         this.shelter = shelter;
@@ -125,7 +125,6 @@ public class Pet {
         this.preAdoption = requestDTO.getPreAdoption();
         this.vaccinated = requestDTO.getVaccinated();
         this.extra = requestDTO.getExtra();
-        this.introduction = requestDTO.getIntroduction();
         this.personality = requestDTO.getPersonality();
         this.exerciseLevel = requestDTO.getExerciseLevel();
     }

--- a/backend/src/main/java/com/example/tenpaws/domain/pet/service/AIDescriptionService.java
+++ b/backend/src/main/java/com/example/tenpaws/domain/pet/service/AIDescriptionService.java
@@ -1,80 +1,82 @@
-package com.example.tenpaws.domain.recommendation.service;
+package com.example.tenpaws.domain.pet.service;
 
 import com.example.tenpaws.domain.pet.dto.PetRequestDTO;
 import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import okhttp3.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 @Service
 @RequiredArgsConstructor
-//@Transactional http 요청 보내므로, 트랜잭션 관리가 필요하지 않다.
-public class ApiService {
+public class AIDescriptionService {
 
     @Value("${openai.api.key}")
     private String API_KEY;
-
-    private static final String API_URL = "https://api.openai.com/v1/chat/completions";
-    private static final Logger logger = LoggerFactory.getLogger(ApiService.class);
-
+    @Value("${openai.api.url:https://api.openai.com/v1/chat/completions}")
+    private String apiUrl;
     private final OkHttpClient client = new OkHttpClient();
     private final ObjectMapper objectMapper = new ObjectMapper()
             .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
-    public String getRecommendation(String prompt) throws IOException {
+    public String generatePetIntroduction(PetRequestDTO petRequestDTO) throws IOException {
+        String prompt = createPrompt(petRequestDTO);
+
         ChatRequest chatRequest = new ChatRequest(prompt);
         String json = objectMapper.writeValueAsString(chatRequest);
-        logger.info("Sending request to OpenAI API: {}", json);
 
         Request request = new Request.Builder()
-                .url(API_URL)
+                .url(apiUrl)
                 .post(RequestBody.create(json, MediaType.parse("application/json")))
                 .addHeader("Authorization", "Bearer " + API_KEY)
                 .build();
 
         try (Response response = client.newCall(request).execute()) {
             if (!response.isSuccessful()) {
-                logger.error("OpenAI API call failed with status: {}", response.code());
                 throw new IOException("Unexpected response: " + response);
             }
-
             String responseBody = response.body().string();
-            logger.info("Received JSON response: {}", responseBody);
-
-            // 응답 파싱
             Map<String, Object> jsonResponse = objectMapper.readValue(responseBody, Map.class);
             List<Map<String, Object>> choices = (List<Map<String, Object>>) jsonResponse.get("choices");
-
             if (choices != null && !choices.isEmpty()) {
                 Map<String, Object> message = (Map<String, Object>) choices.get(0).get("message");
-                if (message != null) {
-                    String content = (String) message.get("content");
-                    logger.info("Parsed content: {}", content);
-                    return content;
-                }
+                return (String) message.get("content");
             }
-            throw new IOException("Unexpected response format");
+            throw new IOException("Unexpected API response");
         }
     }
 
-    @Getter
-    @Setter
+    private String createPrompt(PetRequestDTO petRequestDTO) {
+        return String.format(
+                "당신은 보호소에 입소한 반려동물이에요. 다음 반려동물에 대한 자기소개를 귀엽게 작성해 주세요:\n" +
+                        "이름: %s\n" +
+                        "종: %s\n" +
+                        "크기: %s\n" +
+                        "나이: %s\n" +
+                        "성별: %s\n" +
+                        "성격: %s\n" +
+                        "활동량: %s\n" +
+                        "보호소 입소 이유: %s\n",
+                petRequestDTO.getPetName(),
+                petRequestDTO.getSpecies(),
+                petRequestDTO.getSize(),
+                petRequestDTO.getAge(),
+                petRequestDTO.getGender(),
+                petRequestDTO.getPersonality(),
+                petRequestDTO.getExerciseLevel(),
+                petRequestDTO.getReason()
+        );
+    }
+
     public static class ChatRequest {
-        private String model = "gpt-4o-mini";
+        private String model = "gpt-4o-mini"; // 모델 선택
         private Message[] messages;
 
         public ChatRequest(String prompt) {
@@ -93,23 +95,4 @@ public class ApiService {
             }
         }
     }
-
-//    @Getter
-//    @Setter
-//    public static class AiResponse {
-//        private List<Choice> choices;
-//
-//        @Getter
-//        @Setter
-//        public static class Choice {
-//            private Message message;
-//        }
-//
-//        @Getter
-//        @Setter
-//        public static class Message {
-//            private String content;
-//        }
-//    }
-
 }

--- a/backend/src/main/java/com/example/tenpaws/domain/recommendation/service/RecommendService.java
+++ b/backend/src/main/java/com/example/tenpaws/domain/recommendation/service/RecommendService.java
@@ -48,6 +48,7 @@ public class RecommendService {
 
             // Step 3: 보호소에서 등록된 Pet 중 제외된 ID를 필터링
             List<Pet> filteredPets = petRepository.findAll().stream()
+                    .filter(pet -> !"APPLIED".equals(pet.getStatus())) // Status가 APPLIED가 아닌 경우
                     .filter(pet -> !excludedPetIds.contains(pet.getId()))
                     .collect(Collectors.toList());
             // No pets avaliable이 발생하면 추천된 반려동물 id 목록 초기화
@@ -75,15 +76,12 @@ public class RecommendService {
         "- Size: %s\n" +
         "- Personality: %s\n" +
         "- Exercise Level: %s\n\n" +
-        "현재 보호소에 있는 아이들은 다음과 같아요:\n%s\n\n" +
-        "위 정보를 바탕으로 한 마리의 아이를 추천해주세요.\n" +
-        "추천하는 아이의 이야기를 다음과 같은 형식으로 들려주세요:\n" +
+        "추천 가능한 반려동물 목록은 다음과 같습니다:\n%s\n\n" +
+        "이중에서 한 마리를 추천해주세요. 추천하는 아이의 이야기를 다음과 같은 형식으로 들려주세요:\n" +
         "1. 자기소개 형식으로 작성해주세요\n" +
         "2. 보호소에 오게 된 사연을 포함하여 아이의 이야기를 들려주세요\n" + // 스토리텔링 요청 추가
         "3. 입양 희망자와 잘 맞을 것 같은 이유를 구체적으로 설명해주세요\n" +
-        "4. Status가 APPLIED인 아이는 추천하지 말아주세요\n" +
-        "5. 마지막에 반드시 (Id: ?) 형식으로 추천하는 아이의 ID를 포함해주세요\n" +
-        "6. 부정적인 표현이나 '완벽하게 맞지 않지만' 같은 문구는 사용하지 말아주세요",
+        "4. 마지막에 반드시 (Id: ?) 형식으로 추천하는 아이의 ID를 포함해주세요\n",
         size, personality, exerciseLevel, petDescriptions);
 
             // Step 5: OpenAI 호출


### PR DESCRIPTION
## 🛰️ Issue Number
- #25 
## 🪐 작업 내용
- 동물의 자기소개란을 추가하였습니다. 보호소가 동물 생성시 그 정보를 바탕으로 바로 AI가 해당 동물의 자기소개를 만들어 저장시키는 기능을 추가하였습니다.
- 동물 추천해주는 AI 로직에서 서버에서 이미 필터를 했거나 더 필터링 할 수 있는 부분을 추가하여 AI에게 필요한 정보만 전달하고 명령하도록 수정하였습니다.

## 📚 Reference

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
- [x] Project를 지정했나요?

## ✅ PR 포인트 & 궁금한 점
- close #25 
