### PR TITLE
fix : Docker 볼륨 경로를 SpringBoot 컨테이너 루트 디렉토리의 /uploads 로 수정

### DIFF
--- a/docker-compose.template.yml
+++ b/docker-compose.template.yml
@@ -23,7 +23,7 @@ services:
       SPRING_DATASOURCE_USERNAME: MYSQL_USERNAME_PLACEHOLDER
       SPRING_DATASOURCE_PASSWORD: MYSQL_PASSWORD_PLACEHOLDER
     volumes:
-      - uploads_data:/home/ubuntu/tenpaws-server/uploads  # 업로드 디렉토리 마운트
+      - uploads_data:/uploads  # 업로드 디렉토리 마운트
     entrypoint: >
      /bin/sh -c "java -jar project.jar --spring.config.location=file:/home/ubuntu/tenpaws-server/src/main/resources/application.properties"
     logging:


### PR DESCRIPTION
## 🪐 작업 내용
- 컨테이너가 재시작되거나 새로운 컨테이너로 교체될 때 동물 이미지 파일들이 초기화되는 문제 해결
- 이미지 파일들이 컨테이너 내부의 /uploads/images 디렉토리에 저장되고 있으므로 루트 디렉토리의 /uploads 폴더를 도커 볼륨으로 마운트
- EC2 호스트의 Docker 볼륨에 데이터 영구 저장, 컨테이너 재시작 및 교체되어도 이미지 파일을 보존하도록 설정

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
- [x] Project를 지정했나요?

## ✅ PR 포인트 & 궁금한 점
- Spring Boot 애플리케이션에서 이미지 업로드 시 직접 S3에 저장하도록 마이그레이션 필요